### PR TITLE
Add machine pricing display feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ COPY requirements.txt .
 
 RUN pip3 install -r requirements.txt
 
+# Download pricing.yml and store it in the container
+RUN wget https://raw.githubusercontent.com/Cyclenerd/google-cloud-pricing-cost-calculator/master/pricing.yml -O pricing.yml
+
 COPY . .
 
 RUN chown -R nonroot:nonroot /app

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+import yaml
 from flask import *
 from all_functions import *
 import json
@@ -41,6 +42,11 @@ def eueea():
     country_code = get_country_codes()
     return is_eea(country_code)
 
+@app.route('/machine_pricing', methods=['GET'])
+def machine_pricing():
+    with open('pricing.yml', 'r') as file:
+        pricing_data = yaml.safe_load(file)
+    return render_template('machine_pricing.html', pricing_data=pricing_data)
 
 if __name__ == '__main__':
     app.run(debug=False)

--- a/templates/machine_pricing.html
+++ b/templates/machine_pricing.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Machine Pricing</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+</head>
+<body>
+<div class="container mt-4">
+    <h1>Machine Type Pricing</h1>
+    <div class="table-responsive">
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Machine Type</th>
+                    <th>Region</th>
+                    <th>Hourly Rate</th>
+                    <th>Monthly Rate</th>
+                    <th>Monthly Rate (1 Year)</th>
+                    <th>Monthly Rate (3 Years)</th>
+                    <th>Spot Hourly Rate</th>
+                    <th>Spot Monthly Rate</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for machine_type, regions in pricing_data['compute']['instance'].items() %}
+                    {% for region, rates in regions.items() %}
+                        <tr>
+                            <td>{{ machine_type }}</td>
+                            <td>{{ region }}</td>
+                            <td>{{ rates['hour'] }}</td>
+                            <td>{{ rates['month'] }}</td>
+                            <td>{{ rates['month_1y'] }}</td>
+                            <td>{{ rates['month_3y'] }}</td>
+                            <td>{{ rates['hour_spot'] }}</td>
+                            <td>{{ rates['month_spot'] }}</td>
+                        </tr>
+                    {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+</body>
+</html>


### PR DESCRIPTION
Related to #4

Implements the functionality to parse and display GCP machine type pricing information from a YAML file in a web application.
- Adds a command in the `Dockerfile` to download `pricing.yml` during the build process and store it in the container.
- Modifies `main.py` to:
  - Import the `yaml` module for parsing YAML files.
  - Add a new route `/machine_pricing` that handles GET requests, parses the `pricing.yml` file, and passes the data to a new template for rendering.
- Creates a new HTML template `machine_pricing.html` that:
  - Uses Bootstrap theming to format the pricing information as rows organized by machine type.
  - Dynamically generates a table displaying machine types, regions, and various pricing rates based on the parsed YAML data.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/matdevdug/gcp-iam-reference/issues/4?shareId=cc16f16a-e24f-4ee6-a426-ab550b9104df).